### PR TITLE
Simplify buffering, add Kafka defaults

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,10 +12,9 @@ prost = "0.9"
 rdkafka = "0.28"
 solana-logger = { version = "=1.9.5" }
 solana-accountsdb-plugin-interface = { version = "=1.9.5" }
-tokio = { version = "1.16", features = ["sync"] }
 log = "0.4"
-serde_json = "1.0.78"
-serde = { version = "1.0.136", features = ["derive"] }
+serde_json = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 simple-error = "0.2.3"
 
 [build-dependencies]

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,5 +1,1 @@
-pub enum Event {
-    UpdateAccount(UpdateAccountEvent)
-}
-
 include!(concat!(env!("OUT_DIR"), "/blockdaemon.solana.accountsdb_plugin_kafka.types.rs"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,10 +6,10 @@ mod plugin;
 mod publisher;
 
 pub use {
-    config::Config,
+    config::{Config, Producer},
     event::*,
     plugin::KafkaPlugin,
-    publisher::{Publisher, PublisherHandle},
+    publisher::Publisher,
 };
 
 #[no_mangle]

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -1,103 +1,42 @@
 use {
     crate::*,
-    log::error,
-    rdkafka::producer::{
-        FutureProducer,
-        FutureRecord,
-        future_producer::OwnedDeliveryResult
-    },
     prost::Message,
-    std::{
-        future::Future,
-        time::Duration,
+    rdkafka::{
+        error::KafkaError,
+        producer::{BaseRecord, Producer as KafkaProducer},
     },
-    tokio::sync::{mpsc, oneshot},
+    std::time::Duration,
 };
 
 pub struct Publisher {
-    events_rx: mpsc::Receiver<Event>,
-    finish_tx: Option<oneshot::Sender<()>>,
-
-    producer: FutureProducer,
-    produce_timeout: Duration,
+    producer: Producer,
+    shutdown_timeout: Duration,
     update_account_topic: String,
 }
 
 impl Publisher {
-    /// Create new mpsc channel and publisher loop future.
-    pub fn spawn(
-        producer: FutureProducer,
-        config: &Config,
-    ) -> (PublisherHandle, impl Future<Output=()>) {
-        // Channel to send events from plugin thread(s) to Publisher routine.
-        let (events_tx, events_rx) = mpsc::channel(config.buffer_size);
-
-        // One-shot channel to relay Publisher exit.
-        let (finish_tx, finish_rx) = oneshot::channel::<()>();
-
-        // Create publisher loop future.
-        let publisher = Publisher {
-            events_rx,
-            finish_tx: Some(finish_tx),
-
+    pub fn new(producer: Producer, config: &Config) -> Self {
+        Self {
             producer,
-            produce_timeout: Duration::from_millis(config.produce_timeout_ms),
+            shutdown_timeout: Duration::from_millis(config.shutdown_timeout_ms),
             update_account_topic: config.update_account_topic.clone(),
-        };
-        let fut = publisher.run();
-
-        let handler = PublisherHandle { events_tx, finish_rx };
-        (handler, fut)
-    }
-
-    async fn run(mut self) {
-        while let Some(item) = self.events_rx.recv().await {
-            let fut = match item {
-                Event::UpdateAccount(ev) => self.produce_update_account(ev)
-            };
-            if let Err(e) = fut.await {
-                error!("Failed to produce event: {:?}", e);
-            }
         }
     }
 
-    async fn produce_update_account(&self, ev: UpdateAccountEvent) -> OwnedDeliveryResult {
+    pub fn update_account(&self, ev: UpdateAccountEvent) -> Result<(), KafkaError> {
         let buf = ev.encode_to_vec();
-        let record = FutureRecord::<(), _>::to(&self.update_account_topic)
+        let record = BaseRecord::<Vec<u8>, _>::to(&self.update_account_topic)
+            .key(&ev.pubkey)
             .payload(&buf);
-        self.producer.send(record, self.produce_timeout).await
+        match self.producer.send(record) {
+            Ok(_) => Ok(()),
+            Err((e, _)) => Err(e),
+        }
     }
 }
 
 impl Drop for Publisher {
     fn drop(&mut self) {
-        // Send oneshot notice back to receiver to inform about successful closure.
-        let _ = self.finish_tx
-            .take()
-            .expect("finish_tx disappeared")
-            .send(());
-    }
-}
-
-/// PublisherHandle allows communicating with the Publisher loop.
-pub struct PublisherHandle {
-    events_tx: mpsc::Sender<Event>,
-    finish_rx: oneshot::Receiver<()>,
-}
-
-impl PublisherHandle {
-    /// Send an event to the rdkafka Publisher loop.
-    /// Blocks if the channel and producer buffers are full.
-    pub fn blocking_send(&self, ev: Event) -> Result<(), mpsc::error::SendError<Event>> {
-        self.events_tx.blocking_send(ev)
-    }
-
-    /// Signal graceful close.
-    /// Blocks until the publisher loop has exited.
-    pub fn blocking_close(self) {
-        // Drop sender handle, signaling "close" to the publisher loop.
-        drop(self.events_tx);
-        // Wait until the publisher loop exits.
-        let _ = self.finish_rx.blocking_recv();
+        self.producer.flush(self.shutdown_timeout);
     }
 }


### PR DESCRIPTION
- Removes tokio
- Removes bounded mpsc channel buffering
- Removes publisher loop
- Send events directly to rdkafka::ThreadedProducer