### PR TITLE
Made dependencies consistent to fix 1.10 build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ crate-type = ["cdylib", "rlib"]
 prost = "0.11"
 rdkafka = { version = "0.28", features = ["ssl-vendored", "sasl"] }
 solana-geyser-plugin-interface = { version = "=1.10.32" }
-solana-logger = { version = "=1.11.4" }
+solana-logger = { version = "=1.10.32" }
 solana-program = { version = "=1.10.32" }
-solana-transaction-status = { version = "=1.11.4" }
+solana-transaction-status = { version = "=1.10.32" }
 log = "0.4"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
The Cargo.toml file on the 1.10 branch currently has a mix of Solana 1.10 and 1.11 dependencies, which don't work together out-of-the-box.  This change just moves all dependencies to 1.10 (since it is the 1.10 branch).