### PR TITLE
Switch to non-vendored OpenSSL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 prost = "0.11"
-rdkafka = { version = "0.29", features = ["ssl-vendored", "sasl"] }
+rdkafka = { version = "0.29", features = ["ssl", "sasl"] }
 solana-geyser-plugin-interface = { version = "=1.14.16" }
 solana-logger = { version = "=1.14.16" }
 solana-program = { version = "=1.14.16" }


### PR DESCRIPTION
Avoids a build error in the openssl-src crate.