### PR TITLE
Make build compatible with protoc 3.12-3.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Find binary releases at: https://github.com/Blockdaemon/solana-accountsdb-plugin
 
 ### Building from source
 
+#### Prerequisites
+
+You will need version 3.12 or later of the protobuf compiler `protoc` installed.
+
+#### Build
+
 ```shell
 cargo build --release
 ```

--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,7 @@ use std::io::Result;
 fn main() -> Result<()> {
     let mut config = prost_build::Config::new();
     config.boxed(".blockdaemon.solana.accountsdb_plugin_kafka.types.MessageWrapper");
+    config.protoc_arg("--experimental_allow_proto3_optional");
     config.compile_protos(&["proto/event.proto"], &["proto/"])?;
     Ok(())
 }


### PR DESCRIPTION
The extra argument makes the build work for earlier versions of protoc and is ignored by later versions.