### PR TITLE
feat: buffer account updates until confirmed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,6 +411,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,6 +567,20 @@ dependencies = [
  "darling_core 0.23.0",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -906,6 +926,12 @@ checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
 dependencies = [
  "byteorder",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -2197,6 +2223,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "cargo-lock",
+ "dashmap",
  "git-version",
  "http",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ solana-transaction-status = { version = "4.0.0-beta" }
 solana-transaction-status-client-types = { version = "4.0.0-beta" }
 
 bytes = "*"
+dashmap = "*"
 http = "*"
 http-body-util = "*"
 hyper = { version = "*", features = ["http1", "server"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,7 +13,9 @@
 // limitations under the License.
 
 use {
-    crate::{PrometheusService, prom::StatsThreadedProducerContext},
+    crate::server::{
+        HttpService, prom::StatsThreadedProducerContext, subscriptions::AccountSubscriptions,
+    },
     agave_geyser_plugin_interface::geyser_plugin_interface::{
         GeyserPluginError, Result as PluginResult,
     },
@@ -98,8 +100,10 @@ impl Config {
         self.set_default("partitioner", "murmur2_random");
     }
 
-    pub fn create_prometheus(&self) -> IoResult<Option<PrometheusService>> {
-        self.prometheus.map(PrometheusService::new).transpose()
+    pub fn create_http_service(&self, subs: AccountSubscriptions) -> IoResult<Option<HttpService>> {
+        self.prometheus
+            .map(|addr| HttpService::new(addr, subs))
+            .transpose()
     }
 }
 
@@ -117,8 +121,6 @@ pub struct ConfigFilter {
     pub program_ignores: Vec<String>,
     /// List of programs to include
     pub program_filters: Vec<String>,
-    // List of accounts to include
-    pub account_filters: Vec<String>,
     /// Publish all accounts on startup.
     pub publish_all_accounts: bool,
     /// Publish vote transactions.
@@ -137,7 +139,6 @@ impl Default for ConfigFilter {
             transaction_topic: "".to_owned(),
             program_ignores: Vec::new(),
             program_filters: Vec::new(),
-            account_filters: Vec::new(),
             publish_all_accounts: false,
             include_vote_transactions: true,
             include_failed_transactions: true,

--- a/src/confirmed_accounts.rs
+++ b/src/confirmed_accounts.rs
@@ -1,0 +1,582 @@
+use {
+    crate::{SlotStatus, UpdateAccountEvent},
+    log::{debug, error, warn},
+    solana_pubkey::Pubkey,
+    std::collections::{HashMap, HashSet},
+};
+
+const STALE_UNCONFIRMED_SLOT_RETENTION: u64 = 4096;
+
+#[derive(Debug, Default)]
+struct SlotNode {
+    parent: Option<u64>,
+    children: HashSet<u64>,
+    status: Option<SlotStatus>,
+    is_confirmed: bool,
+    is_dead: bool,
+    emitted: bool,
+}
+
+#[derive(Debug, Default)]
+pub struct ConfirmedAccounts {
+    pending_updates: HashMap<u64, HashMap<Pubkey, UpdateAccountEvent>>,
+    slots: HashMap<u64, SlotNode>,
+    confirmed_slots: HashSet<u64>,
+    dead_slots: HashSet<u64>,
+    highest_confirmed_slot: Option<u64>,
+    highest_observed_slot: u64,
+}
+
+#[derive(Debug, Default)]
+pub struct SlotTransitionResult {
+    pub newly_confirmed_slots: Vec<u64>,
+    pub confirmed_updates: Vec<UpdateAccountEvent>,
+    pub dead_slots_cleaned: Vec<u64>,
+    pub stale_slots_evicted: Vec<u64>,
+}
+
+impl ConfirmedAccounts {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn record_account(&mut self, ev: UpdateAccountEvent) {
+        self.update_highest_observed_slot(ev.slot);
+
+        if self.dead_slots.contains(&ev.slot) {
+            return;
+        }
+
+        let pubkey = match Pubkey::try_from(ev.pubkey.as_slice()) {
+            Ok(pubkey) => pubkey,
+            Err(error) => {
+                error!(
+                    "dropping account update for slot {} with invalid pubkey bytes: {error}",
+                    ev.slot
+                );
+                return;
+            }
+        };
+
+        let slot = ev.slot;
+        let node = self.slot_node_mut(slot);
+        if node.is_dead || node.emitted {
+            return;
+        }
+
+        self.pending_updates
+            .entry(slot)
+            .or_default()
+            .insert(pubkey, ev);
+    }
+
+    pub fn record_slot_status(
+        &mut self,
+        slot: u64,
+        parent: Option<u64>,
+        status: SlotStatus,
+    ) -> SlotTransitionResult {
+        self.update_highest_observed_slot(slot);
+
+        if self.dead_slots.contains(&slot) && !matches!(status, SlotStatus::Dead) {
+            return SlotTransitionResult::default();
+        }
+
+        {
+            let node = self.slot_node_mut(slot);
+            node.status = Some(status);
+        }
+
+        if let Some(parent_slot) = parent {
+            let existing_parent = self.slot_node_mut(slot).parent;
+            match existing_parent {
+                Some(known_parent) if known_parent != parent_slot => {
+                    error!(
+                        "slot {} received conflicting parents: keeping {}, ignoring {}",
+                        slot, known_parent, parent_slot
+                    );
+                }
+                None => {
+                    self.slot_node_mut(slot).parent = Some(parent_slot);
+                }
+                Some(_) => {}
+            }
+            self.mark_parent_child(parent_slot, slot);
+        }
+
+        let mut result = SlotTransitionResult::default();
+        if matches!(status, SlotStatus::Dead) {
+            result.dead_slots_cleaned = self.cleanup_dead_subtree(slot);
+        } else if Self::is_confirming_status(status) {
+            let mut current = Some(slot);
+            while let Some(current_slot) = current {
+                let Some(node) = self.slots.get(&current_slot) else {
+                    break;
+                };
+                if node.is_dead || node.is_confirmed {
+                    break;
+                }
+                let parent_slot = node.parent;
+                self.mark_confirmed(
+                    current_slot,
+                    &mut result.newly_confirmed_slots,
+                    &mut result.confirmed_updates,
+                );
+                current = parent_slot;
+            }
+        }
+
+        result.stale_slots_evicted = self.evict_stale_unconfirmed_slots();
+        result
+    }
+
+    #[cfg(test)]
+    fn pending_count_for(&self, slot: u64) -> usize {
+        self.pending_updates.get(&slot).map_or(0, HashMap::len)
+    }
+
+    #[cfg(test)]
+    fn has_slot(&self, slot: u64) -> bool {
+        self.slots.contains_key(&slot)
+    }
+
+    #[cfg(test)]
+    fn is_confirmed(&self, slot: u64) -> bool {
+        self.slots.get(&slot).is_some_and(|node| node.is_confirmed)
+    }
+
+    fn slot_node_mut(&mut self, slot: u64) -> &mut SlotNode {
+        self.slots.entry(slot).or_default()
+    }
+
+    fn update_highest_observed_slot(&mut self, slot: u64) {
+        self.highest_observed_slot = self.highest_observed_slot.max(slot);
+    }
+
+    fn mark_parent_child(&mut self, parent: u64, child: u64) {
+        self.slot_node_mut(parent).children.insert(child);
+    }
+
+    fn mark_confirmed(
+        &mut self,
+        slot: u64,
+        newly_confirmed_slots: &mut Vec<u64>,
+        confirmed_updates: &mut Vec<UpdateAccountEvent>,
+    ) {
+        let parent = {
+            let node = self.slot_node_mut(slot);
+            if node.is_dead || node.is_confirmed {
+                return;
+            }
+            node.is_confirmed = true;
+            node.emitted = true;
+            node.parent
+        };
+
+        self.confirmed_slots.insert(slot);
+        self.highest_confirmed_slot = Some(
+            self.highest_confirmed_slot
+                .map_or(slot, |current| current.max(slot)),
+        );
+        newly_confirmed_slots.push(slot);
+
+        let drained_updates = self.drain_slot_updates(slot);
+        if !drained_updates.is_empty() {
+            debug!(
+                "slot {} confirmed with {} buffered account updates",
+                slot,
+                drained_updates.len()
+            );
+        }
+        confirmed_updates.extend(drained_updates);
+
+        if let Some(parent_slot) = parent {
+            debug!(
+                "slot {} confirmation allows ancestor inference toward parent {}",
+                slot, parent_slot
+            );
+        }
+    }
+
+    fn drain_slot_updates(&mut self, slot: u64) -> Vec<UpdateAccountEvent> {
+        self.pending_updates
+            .remove(&slot)
+            .map(|updates| updates.into_values().collect())
+            .unwrap_or_default()
+    }
+
+    fn cleanup_dead_subtree(&mut self, slot: u64) -> Vec<u64> {
+        self.slot_node_mut(slot).is_dead = true;
+
+        let mut stack = vec![slot];
+        let mut visited = HashSet::new();
+        let mut subtree = Vec::new();
+
+        while let Some(current) = stack.pop() {
+            if !visited.insert(current) {
+                continue;
+            }
+            subtree.push(current);
+
+            if let Some(node) = self.slots.get(&current) {
+                stack.extend(node.children.iter().copied());
+            }
+        }
+
+        for dead_slot in &subtree {
+            self.dead_slots.insert(*dead_slot);
+            self.pending_updates.remove(dead_slot);
+        }
+
+        for dead_slot in &subtree {
+            self.remove_slot(*dead_slot);
+        }
+
+        if !subtree.is_empty() {
+            debug!(
+                "removed dead subtree rooted at slot {}: {:?}",
+                slot, subtree
+            );
+        }
+
+        subtree
+    }
+
+    fn evict_stale_unconfirmed_slots(&mut self) -> Vec<u64> {
+        if self.highest_observed_slot <= STALE_UNCONFIRMED_SLOT_RETENTION {
+            return Vec::new();
+        }
+
+        let cutoff = self.highest_observed_slot - STALE_UNCONFIRMED_SLOT_RETENTION;
+        let victims: Vec<u64> = self
+            .slots
+            .iter()
+            .filter_map(|(&slot, node)| {
+                if slot >= cutoff || node.is_confirmed || node.status == Some(SlotStatus::Rooted) {
+                    return None;
+                }
+                Some(slot)
+            })
+            .collect();
+
+        for slot in &victims {
+            warn!(
+                "evicting stale unconfirmed slot {} (cutoff {}, highest observed {})",
+                slot, cutoff, self.highest_observed_slot
+            );
+            self.pending_updates.remove(slot);
+        }
+
+        for slot in &victims {
+            self.remove_slot(*slot);
+        }
+
+        self.dead_slots.retain(|slot| *slot >= cutoff);
+
+        victims
+    }
+
+    fn remove_slot(&mut self, slot: u64) {
+        let Some(node) = self.slots.remove(&slot) else {
+            return;
+        };
+
+        self.pending_updates.remove(&slot);
+        self.confirmed_slots.remove(&slot);
+
+        if let Some(parent) = node.parent
+            && let Some(parent_node) = self.slots.get_mut(&parent)
+        {
+            parent_node.children.remove(&slot);
+        }
+
+        for child in node.children {
+            if let Some(child_node) = self.slots.get_mut(&child)
+                && child_node.parent == Some(slot)
+            {
+                child_node.parent = None;
+            }
+        }
+    }
+
+    fn is_confirming_status(status: SlotStatus) -> bool {
+        matches!(status, SlotStatus::Confirmed | SlotStatus::Rooted)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sorted_slots<I>(slots: I) -> Vec<u64>
+    where
+        I: IntoIterator<Item = u64>,
+    {
+        let mut slots: Vec<u64> = slots.into_iter().collect();
+        slots.sort_unstable();
+        slots
+    }
+
+    fn account_event(slot: u64, pubkey_byte: u8, write_version: u64) -> UpdateAccountEvent {
+        UpdateAccountEvent {
+            slot,
+            pubkey: vec![pubkey_byte; 32],
+            lamports: write_version,
+            owner: vec![9; 32],
+            executable: false,
+            rent_epoch: 0,
+            data: vec![write_version as u8],
+            write_version,
+            txn_signature: None,
+            data_version: write_version as u32,
+            is_startup: false,
+            account_age: 0,
+        }
+    }
+
+    #[test]
+    fn buffers_latest_update_per_slot_pubkey() {
+        let mut confirmed = ConfirmedAccounts::new();
+
+        confirmed.record_account(account_event(10, 1, 1));
+        confirmed.record_account(account_event(10, 1, 2));
+
+        assert_eq!(confirmed.pending_count_for(10), 1);
+        let result = confirmed.record_slot_status(10, None, SlotStatus::Confirmed);
+        assert_eq!(result.newly_confirmed_slots, vec![10]);
+        assert_eq!(result.confirmed_updates.len(), 1);
+        assert_eq!(
+            sorted_slots(result.confirmed_updates.iter().map(|event| event.slot)),
+            vec![10]
+        );
+        assert!(result.dead_slots_cleaned.is_empty());
+        assert!(result.stale_slots_evicted.is_empty());
+        assert_eq!(result.confirmed_updates[0].write_version, 2);
+        assert_eq!(confirmed.pending_count_for(10), 0);
+        assert!(confirmed.is_confirmed(10));
+    }
+
+    #[test]
+    fn confirmed_slot_drains_updates_once() {
+        let mut confirmed = ConfirmedAccounts::new();
+        confirmed.record_account(account_event(11, 2, 1));
+
+        let first = confirmed.record_slot_status(11, None, SlotStatus::Confirmed);
+        let second = confirmed.record_slot_status(11, None, SlotStatus::Confirmed);
+
+        assert_eq!(first.newly_confirmed_slots, vec![11]);
+        assert_eq!(first.confirmed_updates.len(), 1);
+        assert_eq!(
+            sorted_slots(first.confirmed_updates.iter().map(|event| event.slot)),
+            vec![11]
+        );
+        assert!(first.dead_slots_cleaned.is_empty());
+        assert!(first.stale_slots_evicted.is_empty());
+        assert_eq!(confirmed.pending_count_for(11), 0);
+        assert!(confirmed.is_confirmed(11));
+        assert!(second.confirmed_updates.is_empty());
+        assert_eq!(second.newly_confirmed_slots.len(), 0);
+        assert!(second.dead_slots_cleaned.is_empty());
+        assert!(second.stale_slots_evicted.is_empty());
+        assert_eq!(confirmed.pending_count_for(11), 0);
+    }
+
+    #[test]
+    fn rooted_slot_drains_updates_once() {
+        let mut confirmed = ConfirmedAccounts::new();
+        confirmed.record_account(account_event(12, 3, 1));
+
+        let result = confirmed.record_slot_status(12, None, SlotStatus::Rooted);
+
+        assert_eq!(result.newly_confirmed_slots, vec![12]);
+        assert_eq!(result.confirmed_updates.len(), 1);
+        assert_eq!(
+            sorted_slots(result.confirmed_updates.iter().map(|event| event.slot)),
+            vec![12]
+        );
+        assert!(result.dead_slots_cleaned.is_empty());
+        assert!(result.stale_slots_evicted.is_empty());
+        assert_eq!(confirmed.pending_count_for(12), 0);
+        assert!(confirmed.is_confirmed(12));
+    }
+
+    #[test]
+    fn confirmed_child_confirms_known_ancestors() {
+        let mut confirmed = ConfirmedAccounts::new();
+        confirmed.record_account(account_event(20, 4, 1));
+        confirmed.record_account(account_event(21, 5, 1));
+        confirmed.record_account(account_event(22, 6, 1));
+        confirmed.record_slot_status(21, Some(20), SlotStatus::Processed);
+        confirmed.record_slot_status(22, Some(21), SlotStatus::Processed);
+
+        let result = confirmed.record_slot_status(22, None, SlotStatus::Confirmed);
+
+        assert_eq!(result.newly_confirmed_slots, vec![22, 21, 20]);
+        assert_eq!(result.confirmed_updates.len(), 3);
+        assert_eq!(
+            sorted_slots(result.confirmed_updates.iter().map(|event| event.slot)),
+            vec![20, 21, 22]
+        );
+        assert!(result.dead_slots_cleaned.is_empty());
+        assert!(result.stale_slots_evicted.is_empty());
+        assert_eq!(confirmed.pending_count_for(20), 0);
+        assert_eq!(confirmed.pending_count_for(21), 0);
+        assert_eq!(confirmed.pending_count_for(22), 0);
+        assert!(confirmed.is_confirmed(20));
+        assert!(confirmed.is_confirmed(21));
+        assert!(confirmed.is_confirmed(22));
+    }
+
+    #[test]
+    fn confirmed_with_missing_parent_stops_inference() {
+        let mut confirmed = ConfirmedAccounts::new();
+        confirmed.record_account(account_event(30, 7, 1));
+
+        let result = confirmed.record_slot_status(30, None, SlotStatus::Confirmed);
+
+        assert_eq!(result.newly_confirmed_slots, vec![30]);
+        assert_eq!(result.confirmed_updates.len(), 1);
+        assert_eq!(
+            sorted_slots(result.confirmed_updates.iter().map(|event| event.slot)),
+            vec![30]
+        );
+        assert!(result.dead_slots_cleaned.is_empty());
+        assert!(result.stale_slots_evicted.is_empty());
+        assert_eq!(confirmed.pending_count_for(30), 0);
+        assert!(confirmed.is_confirmed(30));
+    }
+
+    #[test]
+    fn confirmed_event_with_parent_none_uses_previous_parent_link() {
+        let mut confirmed = ConfirmedAccounts::new();
+        confirmed.record_account(account_event(40, 8, 1));
+        confirmed.record_account(account_event(41, 9, 1));
+        confirmed.record_slot_status(41, Some(40), SlotStatus::Processed);
+
+        let result = confirmed.record_slot_status(41, None, SlotStatus::Confirmed);
+
+        assert_eq!(result.newly_confirmed_slots, vec![41, 40]);
+        assert_eq!(result.confirmed_updates.len(), 2);
+        assert_eq!(
+            sorted_slots(result.confirmed_updates.iter().map(|event| event.slot)),
+            vec![40, 41]
+        );
+        assert!(result.dead_slots_cleaned.is_empty());
+        assert!(result.stale_slots_evicted.is_empty());
+        assert_eq!(confirmed.pending_count_for(40), 0);
+        assert_eq!(confirmed.pending_count_for(41), 0);
+        assert!(confirmed.is_confirmed(40));
+        assert!(confirmed.is_confirmed(41));
+    }
+
+    #[test]
+    fn dead_slot_removes_own_updates() {
+        let mut confirmed = ConfirmedAccounts::new();
+        confirmed.record_account(account_event(50, 10, 1));
+
+        let result = confirmed.record_slot_status(50, None, SlotStatus::Dead);
+
+        assert_eq!(result.dead_slots_cleaned, vec![50]);
+        assert!(result.confirmed_updates.is_empty());
+        assert!(result.newly_confirmed_slots.is_empty());
+        assert!(result.stale_slots_evicted.is_empty());
+        assert!(!confirmed.has_slot(50));
+        assert_eq!(confirmed.pending_count_for(50), 0);
+        assert!(!confirmed.is_confirmed(50));
+    }
+
+    #[test]
+    fn dead_slot_removes_known_descendants() {
+        let mut confirmed = ConfirmedAccounts::new();
+        confirmed.record_account(account_event(60, 11, 1));
+        confirmed.record_account(account_event(61, 12, 1));
+        confirmed.record_slot_status(61, Some(60), SlotStatus::Processed);
+
+        let result = confirmed.record_slot_status(60, None, SlotStatus::Dead);
+
+        assert_eq!(sorted_slots(result.dead_slots_cleaned), vec![60, 61]);
+        assert!(result.confirmed_updates.is_empty());
+        assert!(result.newly_confirmed_slots.is_empty());
+        assert!(result.stale_slots_evicted.is_empty());
+        assert!(!confirmed.has_slot(60));
+        assert!(!confirmed.has_slot(61));
+        assert_eq!(confirmed.pending_count_for(60), 0);
+        assert_eq!(confirmed.pending_count_for(61), 0);
+        assert!(!confirmed.is_confirmed(60));
+        assert!(!confirmed.is_confirmed(61));
+    }
+
+    #[test]
+    fn dead_slot_prevents_later_emission() {
+        let mut confirmed = ConfirmedAccounts::new();
+        confirmed.record_account(account_event(70, 13, 1));
+        confirmed.record_slot_status(70, None, SlotStatus::Dead);
+
+        let result = confirmed.record_slot_status(70, None, SlotStatus::Confirmed);
+
+        assert!(result.confirmed_updates.is_empty());
+        assert!(result.newly_confirmed_slots.is_empty());
+        assert!(result.dead_slots_cleaned.is_empty());
+        assert!(result.stale_slots_evicted.is_empty());
+        assert_eq!(confirmed.pending_count_for(70), 0);
+        assert!(!confirmed.has_slot(70));
+        assert!(!confirmed.is_confirmed(70));
+    }
+
+    #[test]
+    fn repeated_confirmed_status_is_idempotent() {
+        let mut confirmed = ConfirmedAccounts::new();
+        confirmed.record_account(account_event(80, 14, 1));
+
+        let _ = confirmed.record_slot_status(80, None, SlotStatus::Confirmed);
+        let result = confirmed.record_slot_status(80, None, SlotStatus::Rooted);
+
+        assert!(result.confirmed_updates.is_empty());
+        assert!(result.newly_confirmed_slots.is_empty());
+        assert!(result.dead_slots_cleaned.is_empty());
+        assert!(result.stale_slots_evicted.is_empty());
+        assert_eq!(confirmed.pending_count_for(80), 0);
+        assert!(confirmed.is_confirmed(80));
+    }
+
+    #[test]
+    fn stale_fallback_evicts_old_unconfirmed_slots() {
+        let mut confirmed = ConfirmedAccounts::new();
+        confirmed.record_account(account_event(1, 15, 1));
+
+        let result = confirmed.record_slot_status(
+            STALE_UNCONFIRMED_SLOT_RETENTION + 10,
+            None,
+            SlotStatus::Processed,
+        );
+
+        assert_eq!(result.stale_slots_evicted, vec![1]);
+        assert!(result.confirmed_updates.is_empty());
+        assert!(result.newly_confirmed_slots.is_empty());
+        assert!(result.dead_slots_cleaned.is_empty());
+        assert!(!confirmed.has_slot(1));
+        assert_eq!(confirmed.pending_count_for(1), 0);
+        assert!(!confirmed.is_confirmed(1));
+    }
+
+    #[test]
+    fn stale_fallback_does_not_evict_confirmed_slots() {
+        let mut confirmed = ConfirmedAccounts::new();
+        confirmed.record_account(account_event(2, 16, 1));
+        let _ = confirmed.record_slot_status(2, None, SlotStatus::Confirmed);
+
+        let result = confirmed.record_slot_status(
+            STALE_UNCONFIRMED_SLOT_RETENTION + 10,
+            None,
+            SlotStatus::Processed,
+        );
+
+        assert!(result.stale_slots_evicted.is_empty());
+        assert!(result.confirmed_updates.is_empty());
+        assert!(result.newly_confirmed_slots.is_empty());
+        assert!(result.dead_slots_cleaned.is_empty());
+        assert!(confirmed.has_slot(2));
+        assert!(confirmed.is_confirmed(2));
+        assert_eq!(confirmed.pending_count_for(2), 0);
+    }
+}

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -22,7 +22,6 @@ pub struct Filter {
     pub publish_all_accounts: bool,
     pub program_ignores: HashSet<[u8; 32]>,
     pub program_filters: HashSet<[u8; 32]>,
-    pub account_filters: HashSet<[u8; 32]>,
     pub include_vote_transactions: bool,
     pub include_failed_transactions: bool,
 
@@ -47,11 +46,6 @@ impl Filter {
                 .iter()
                 .flat_map(|p| Pubkey::from_str(p).ok().map(|p| p.to_bytes()))
                 .collect(),
-            account_filters: config
-                .account_filters
-                .iter()
-                .flat_map(|p| Pubkey::from_str(p).ok().map(|p| p.to_bytes()))
-                .collect(),
             include_vote_transactions: config.include_vote_transactions,
             include_failed_transactions: config.include_failed_transactions,
 
@@ -69,13 +63,6 @@ impl Filter {
                 !self.program_ignores.contains(key)
                     && (self.program_filters.is_empty() || self.program_filters.contains(key))
             }
-            Err(_error) => true,
-        }
-    }
-
-    pub fn wants_account(&self, account: &[u8]) -> bool {
-        match <&[u8; 32]>::try_from(account) {
-            Ok(key) => self.account_filters.contains(key),
             Err(_error) => true,
         }
     }
@@ -159,43 +146,6 @@ mod tests {
         assert!(
             !filter.wants_program(
                 &Pubkey::from_str("cndy3Z4yapfJBmL3ShUp5exZKqR3z33thTzeNMm2gRZ")
-                    .unwrap()
-                    .to_bytes()
-            )
-        );
-    }
-
-    #[test]
-    fn test_account_filter() {
-        let config = ConfigFilter {
-            program_filters: vec!["9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin".to_owned()],
-            account_filters: vec!["5KKsLVU6TcbVDK4BS6K1DGDxnh4Q9xjYJ8XaDCG5t8ht".to_owned()],
-            ..Default::default()
-        };
-
-        let filter = Filter::new(&config);
-        assert_eq!(filter.program_filters.len(), 1);
-        assert_eq!(filter.account_filters.len(), 1);
-
-        println!("{:?}", filter.account_filters);
-        println!(
-            "{:?}",
-            &Pubkey::from_str("5KKsLVU6TcbVDK4BS6K1DGDxnh4Q9xjYJ8XaDCG5t8ht")
-                .unwrap()
-                .to_bytes()
-        );
-
-        assert!(
-            filter.wants_program(
-                &Pubkey::from_str("9xQeWvG816bUx9EPjHmaT23yvVM2ZWbrrpZb9PusVFin")
-                    .unwrap()
-                    .to_bytes()
-            )
-        );
-
-        assert!(
-            filter.wants_account(
-                &Pubkey::from_str("5KKsLVU6TcbVDK4BS6K1DGDxnh4Q9xjYJ8XaDCG5t8ht")
                     .unwrap()
                     .to_bytes()
             )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 use agave_geyser_plugin_interface::geyser_plugin_interface::GeyserPlugin;
 
 mod config;
+mod confirmed_accounts;
 mod event;
 mod filter;
 mod plugin;
@@ -24,6 +25,7 @@ mod version;
 
 pub use {
     config::{Config, ConfigFilter, Producer},
+    confirmed_accounts::{ConfirmedAccounts, SlotTransitionResult},
     event::*,
     filter::Filter,
     plugin::KafkaPlugin,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,8 @@ mod config;
 mod event;
 mod filter;
 mod plugin;
-mod prom;
 mod publisher;
+mod server;
 mod version;
 
 pub use {
@@ -27,8 +27,10 @@ pub use {
     event::*,
     filter::Filter,
     plugin::KafkaPlugin,
-    prom::PrometheusService,
     publisher::Publisher,
+    server::{
+        HttpService, prom::StatsThreadedProducerContext, subscriptions::AccountSubscriptions,
+    },
 };
 
 #[unsafe(no_mangle)]

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -14,12 +14,12 @@
 
 use {
     crate::{
-        BlockEvent, CompiledInstruction, Config, Filter, InnerInstruction, InnerInstructions,
-        LegacyLoadedMessage, LegacyMessage, LoadedAddresses, MessageAddressTableLookup,
-        MessageHeader, PrometheusService, Publisher, Reward, RewardsAndNumPartitions,
+        BlockEvent, CompiledInstruction, Config, Filter, HttpService, InnerInstruction,
+        InnerInstructions, LegacyLoadedMessage, LegacyMessage, LoadedAddresses,
+        MessageAddressTableLookup, MessageHeader, Publisher, Reward, RewardsAndNumPartitions,
         SanitizedMessage, SanitizedTransaction, SlotStatus, SlotStatusEvent, TransactionEvent,
         TransactionStatusMeta, TransactionTokenBalance, UiTokenAmount, UpdateAccountEvent,
-        V0LoadedMessage, V0Message, sanitized_message,
+        V0LoadedMessage, V0Message, sanitized_message, server::subscriptions::AccountSubscriptions,
     },
     agave_geyser_plugin_interface::geyser_plugin_interface::{
         GeyserPlugin, GeyserPluginError as PluginError, ReplicaAccountInfoV3,
@@ -38,7 +38,8 @@ pub struct KafkaPlugin {
     publisher: Option<Publisher>,
     filter: Option<Vec<Filter>>,
     block_events_topic: Option<(String, bool)>,
-    prometheus: Option<PrometheusService>,
+    http_service: Option<HttpService>,
+    account_subscriptions: AccountSubscriptions,
 }
 
 impl Debug for KafkaPlugin {
@@ -75,12 +76,12 @@ impl GeyserPlugin for KafkaPlugin {
         info!("Created rdkafka::FutureProducer");
 
         let publisher = Publisher::new(producer, &config);
-        let prometheus = config
-            .create_prometheus()
+        let http_service = config
+            .create_http_service(self.account_subscriptions.clone())
             .map_err(|error| PluginError::Custom(Box::new(error)))?;
         self.publisher = Some(publisher);
         self.filter = Some(config.filters.iter().map(Filter::new).collect());
-        self.prometheus = prometheus;
+        self.http_service = http_service;
         self.block_events_topic = config
             .block_events_topic
             .map(|b| (b.topic, b.wrap_messages));
@@ -92,8 +93,8 @@ impl GeyserPlugin for KafkaPlugin {
     fn on_unload(&mut self) {
         self.publisher = None;
         self.filter = None;
-        if let Some(prometheus) = self.prometheus.take() {
-            prometheus.shutdown();
+        if let Some(http_service) = self.http_service.take() {
+            http_service.shutdown();
         }
     }
 
@@ -110,9 +111,16 @@ impl GeyserPlugin for KafkaPlugin {
 
         let info = Self::unwrap_update_account(account);
         let publisher = self.unwrap_publisher();
+        let subs = &self.account_subscriptions;
         for filter in filters {
             if !filter.update_account_topic.is_empty() {
-                if !filter.wants_program(info.owner) && !filter.wants_account(info.pubkey) {
+                let wants_program = filter.wants_program(info.owner);
+                let wants_account = match <&[u8; 32]>::try_from(info.pubkey) {
+                    Ok(key) => subs.contains_sync(key),
+                    Err(_) => false,
+                };
+
+                if !wants_program && !wants_account {
                     Self::log_ignore_account_update(info);
                     continue;
                 }
@@ -176,6 +184,7 @@ impl GeyserPlugin for KafkaPlugin {
     ) -> PluginResult<()> {
         let info = Self::unwrap_transaction(transaction);
         let publisher = self.unwrap_publisher();
+        let subs = &self.account_subscriptions;
         for filter in self.unwrap_filters() {
             if !filter.transaction_topic.is_empty() {
                 let is_failed = info.transaction_status_meta.status.is_err();
@@ -193,7 +202,7 @@ impl GeyserPlugin for KafkaPlugin {
                     .iter()
                     .any(|pubkey| {
                         filter.wants_program(pubkey.as_ref())
-                            || filter.wants_account(pubkey.as_ref())
+                            || subs.contains_sync(&pubkey.to_bytes())
                     })
                 {
                     debug!("Ignoring transaction {:?}", info.signature);

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -14,8 +14,8 @@
 
 use {
     crate::{
-        BlockEvent, CompiledInstruction, Config, Filter, HttpService, InnerInstruction,
-        InnerInstructions, LegacyLoadedMessage, LegacyMessage, LoadedAddresses,
+        BlockEvent, CompiledInstruction, Config, ConfirmedAccounts, Filter, HttpService,
+        InnerInstruction, InnerInstructions, LegacyLoadedMessage, LegacyMessage, LoadedAddresses,
         MessageAddressTableLookup, MessageHeader, Publisher, Reward, RewardsAndNumPartitions,
         SanitizedMessage, SanitizedTransaction, SlotStatus, SlotStatusEvent, TransactionEvent,
         TransactionStatusMeta, TransactionTokenBalance, UiTokenAmount, UpdateAccountEvent,
@@ -30,7 +30,10 @@ use {
     log::{debug, error, info, log_enabled},
     rdkafka::util::get_rdkafka_version,
     solana_pubkey::{Pubkey, pubkey},
-    std::fmt::{Debug, Formatter},
+    std::{
+        fmt::{Debug, Formatter},
+        sync::{Mutex, MutexGuard},
+    },
 };
 
 #[derive(Default)]
@@ -40,6 +43,7 @@ pub struct KafkaPlugin {
     block_events_topic: Option<(String, bool)>,
     http_service: Option<HttpService>,
     account_subscriptions: AccountSubscriptions,
+    confirmed_accounts: Mutex<ConfirmedAccounts>,
 }
 
 impl Debug for KafkaPlugin {
@@ -85,6 +89,7 @@ impl GeyserPlugin for KafkaPlugin {
         self.block_events_topic = config
             .block_events_topic
             .map(|b| (b.topic, b.wrap_messages));
+        *self.lock_confirmed_accounts()? = ConfirmedAccounts::new();
         info!("Spawned producer");
 
         Ok(())
@@ -110,41 +115,8 @@ impl GeyserPlugin for KafkaPlugin {
         }
 
         let info = Self::unwrap_update_account(account);
-        let publisher = self.unwrap_publisher();
-        let subs = &self.account_subscriptions;
-        for filter in filters {
-            if !filter.update_account_topic.is_empty() {
-                let wants_program = filter.wants_program(info.owner);
-                let wants_account = match <&[u8; 32]>::try_from(info.pubkey) {
-                    Ok(key) => subs.contains_sync(key),
-                    Err(_) => false,
-                };
-
-                if !wants_program && !wants_account {
-                    Self::log_ignore_account_update(info);
-                    continue;
-                }
-
-                let event = UpdateAccountEvent {
-                    slot,
-                    pubkey: info.pubkey.to_vec(),
-                    lamports: info.lamports,
-                    owner: info.owner.to_vec(),
-                    executable: info.executable,
-                    rent_epoch: info.rent_epoch,
-                    data: info.data.to_vec(),
-                    write_version: info.write_version,
-                    txn_signature: info.txn.map(|v| v.signature().as_ref().to_owned()),
-                    data_version: info.write_version as u32, // Use write_version as data version
-                    is_startup,                              // Use the is_startup parameter
-                    account_age: slot.saturating_sub(info.rent_epoch), // Approximate age from rent epoch
-                };
-
-                publisher
-                    .update_account(event, filter.wrap_messages, &filter.update_account_topic)
-                    .map_err(|e| PluginError::AccountsUpdateError { msg: e.to_string() })?;
-            }
-        }
+        let event = Self::build_update_account_event(info, slot, is_startup);
+        self.lock_confirmed_accounts()?.record_account(event);
 
         Ok(())
     }
@@ -157,6 +129,19 @@ impl GeyserPlugin for KafkaPlugin {
     ) -> PluginResult<()> {
         let publisher = self.unwrap_publisher();
         let value = SlotStatus::from(status.clone());
+        let transition = self
+            .lock_confirmed_accounts()?
+            .record_slot_status(slot, parent, value);
+        if !transition.newly_confirmed_slots.is_empty() {
+            info!(
+                "slot {} newly confirmed slots {:?}, drained {} account updates",
+                slot,
+                transition.newly_confirmed_slots,
+                transition.confirmed_updates.len()
+            );
+        }
+
+        let mut first_error = None;
         for filter in self.unwrap_filters() {
             if !filter.slot_status_topic.is_empty() {
                 let event = SlotStatusEvent {
@@ -168,13 +153,32 @@ impl GeyserPlugin for KafkaPlugin {
                     status_description: Self::get_slot_status_description(&value), // Get human-readable status
                 };
 
-                publisher
-                    .update_slot_status(event, filter.wrap_messages, &filter.slot_status_topic)
-                    .map_err(|e| PluginError::AccountsUpdateError { msg: e.to_string() })?;
+                if let Err(error) = publisher.update_slot_status(
+                    event,
+                    filter.wrap_messages,
+                    &filter.slot_status_topic,
+                ) {
+                    let plugin_error = PluginError::AccountsUpdateError {
+                        msg: error.to_string(),
+                    };
+                    error!(
+                        "failed to publish slot status for slot {}: {plugin_error:?}",
+                        slot
+                    );
+                    if first_error.is_none() {
+                        first_error = Some(plugin_error);
+                    }
+                }
             }
         }
 
-        Ok(())
+        if let Err(error) = self.publish_confirmed_account_updates(transition.confirmed_updates)
+            && first_error.is_none()
+        {
+            first_error = Some(error);
+        }
+
+        first_error.map_or(Ok(()), Err)
     }
 
     fn notify_transaction(
@@ -255,6 +259,14 @@ impl KafkaPlugin {
         Default::default()
     }
 
+    fn lock_confirmed_accounts(&self) -> PluginResult<MutexGuard<'_, ConfirmedAccounts>> {
+        self.confirmed_accounts.lock().map_err(|error| {
+            PluginError::Custom(Box::new(std::io::Error::other(format!(
+                "confirmed_accounts mutex poisoned: {error}"
+            ))))
+        })
+    }
+
     fn unwrap_publisher(&self) -> &Publisher {
         self.publisher.as_ref().expect("publisher is unavailable")
     }
@@ -315,6 +327,91 @@ impl KafkaPlugin {
             }
             ReplicaBlockInfoVersions::V0_0_4(info) => info,
         }
+    }
+
+    fn build_update_account_event(
+        info: &ReplicaAccountInfoV3<'_>,
+        slot: u64,
+        is_startup: bool,
+    ) -> UpdateAccountEvent {
+        UpdateAccountEvent {
+            slot,
+            pubkey: info.pubkey.to_vec(),
+            lamports: info.lamports,
+            owner: info.owner.to_vec(),
+            executable: info.executable,
+            rent_epoch: info.rent_epoch,
+            data: info.data.to_vec(),
+            write_version: info.write_version,
+            txn_signature: info.txn.map(|v| v.signature().as_ref().to_owned()),
+            data_version: info.write_version as u32,
+            is_startup,
+            account_age: slot.saturating_sub(info.rent_epoch),
+        }
+    }
+
+    fn should_publish_account(&self, event: &UpdateAccountEvent) -> bool {
+        // Program-based account publication is being deprecated and is intentionally
+        // unsupported here. Confirmed account publication only follows dynamic
+        // account subscriptions.
+        match <&[u8; 32]>::try_from(event.pubkey.as_slice()) {
+            Ok(key) => self.account_subscriptions.contains_sync(key),
+            Err(_) => false,
+        }
+    }
+
+    fn publish_confirmed_account_updates(
+        &self,
+        updates: Vec<UpdateAccountEvent>,
+    ) -> PluginResult<()> {
+        if updates.is_empty() {
+            return Ok(());
+        }
+
+        let publisher = self.unwrap_publisher();
+        let filters = self.unwrap_filters();
+        let mut first_error = None;
+
+        for event in updates {
+            let mut matched_any_filter = false;
+            for filter in filters {
+                if filter.update_account_topic.is_empty() || !self.should_publish_account(&event) {
+                    continue;
+                }
+
+                matched_any_filter = true;
+                if let Ok(key) = <[u8; 32]>::try_from(event.pubkey.as_slice()) {
+                    info!(
+                        "Matched confirmed account update {} in slot {}",
+                        Pubkey::new_from_array(key),
+                        event.slot
+                    );
+                }
+
+                if let Err(error) = publisher.update_account(
+                    event.clone(),
+                    filter.wrap_messages,
+                    &filter.update_account_topic,
+                ) {
+                    let plugin_error = PluginError::AccountsUpdateError {
+                        msg: error.to_string(),
+                    };
+                    error!(
+                        "failed to publish confirmed account update for slot {}: {plugin_error:?}",
+                        event.slot
+                    );
+                    if first_error.is_none() {
+                        first_error = Some(plugin_error);
+                    }
+                }
+            }
+
+            if !matched_any_filter {
+                Self::log_ignore_account_update(&event.pubkey);
+            }
+        }
+
+        first_error.map_or(Ok(()), Err)
     }
 
     fn build_compiled_instruction(
@@ -606,15 +703,14 @@ impl KafkaPlugin {
         }
     }
 
-    fn log_ignore_account_update(info: &ReplicaAccountInfoV3) {
+    fn log_ignore_account_update(pubkey: &[u8]) {
         if log_enabled!(::log::Level::Debug) {
-            match <&[u8; 32]>::try_from(info.owner) {
+            match <&[u8; 32]>::try_from(pubkey) {
                 Ok(key) => debug!(
                     "Ignoring update for account key: {:?}",
                     Pubkey::new_from_array(*key)
                 ),
-                // Err should never happen because wants_account_key only returns false if the input is &[u8; 32]
-                Err(_err) => debug!("Ignoring update for account key: {:?}", info.owner),
+                Err(_err) => debug!("Ignoring update for account key bytes: {:?}", pubkey),
             };
         }
     }

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -21,11 +21,13 @@ use {
             UPLOAD_TRANSACTIONS_TOTAL,
         },
     },
+    log::info,
     prost::Message,
     rdkafka::{
         error::KafkaError,
         producer::{BaseRecord, Producer, ThreadedProducer},
     },
+    solana_pubkey::Pubkey,
     std::time::Duration,
 };
 
@@ -49,17 +51,27 @@ impl Publisher {
         topic: &str,
     ) -> Result<(), KafkaError> {
         let temp_key;
+        let log_pubkey = Pubkey::try_from(ev.pubkey.as_slice()).ok();
         let (key, buf) = if wrap_messages {
-            (
-                &ev.pubkey.clone(),
-                Self::encode_with_wrapper(Account(Box::new(ev))),
-            )
+            temp_key = ev.pubkey.clone();
+            (&temp_key, Self::encode_with_wrapper(Account(Box::new(ev))))
         } else {
             temp_key = self.copy_and_prepend(ev.pubkey.as_slice(), b'A');
             (&temp_key, ev.encode_to_vec())
         };
+        info!("key: {:?}", key);
         let record = BaseRecord::<Vec<u8>, _>::to(topic).key(key).payload(&buf);
         let result = self.producer.send(record).map(|_| ()).map_err(|(e, _)| e);
+        match log_pubkey {
+            Some(pubkey) => info!(
+                "Published account update for pubkey: {} with key {:?}",
+                pubkey, key
+            ),
+            None => info!(
+                "Published account update with invalid pubkey bytes and key {:?}",
+                key
+            ),
+        }
         UPLOAD_ACCOUNTS_TOTAL
             .with_label_values(&[if result.is_ok() { "success" } else { "failed" }])
             .inc();

--- a/src/publisher.rs
+++ b/src/publisher.rs
@@ -16,7 +16,7 @@ use {
     crate::{
         BlockEvent, Config, MessageWrapper, SlotStatusEvent, TransactionEvent, UpdateAccountEvent,
         message_wrapper::EventMessage::{self, Account, Slot, Transaction},
-        prom::{
+        server::prom::{
             StatsThreadedProducerContext, UPLOAD_ACCOUNTS_TOTAL, UPLOAD_SLOTS_TOTAL,
             UPLOAD_TRANSACTIONS_TOTAL,
         },

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,0 +1,97 @@
+pub mod prom;
+pub mod subscriptions;
+
+use {
+    bytes::Bytes,
+    http::StatusCode,
+    http_body_util::Full,
+    hyper::{Method, Request, Response, body::Incoming, service::service_fn},
+    hyper_util::rt::TokioIo,
+    log::*,
+    prom::metrics_handler,
+    std::{io::Result as IoResult, net::SocketAddr, time::Duration},
+    subscriptions::AccountSubscriptions,
+    tokio::net::TcpListener,
+    tokio::runtime::Runtime,
+};
+
+#[derive(Debug)]
+pub struct HttpService {
+    runtime: Runtime,
+}
+
+impl HttpService {
+    pub fn new(address: SocketAddr, subs: AccountSubscriptions) -> IoResult<Self> {
+        prom::register_metrics();
+
+        let runtime = Runtime::new()?;
+        let listener = runtime.block_on(TcpListener::bind(address))?;
+
+        runtime.spawn(async move {
+            loop {
+                let (stream, _) = match listener.accept().await {
+                    Ok(conn) => conn,
+                    Err(e) => {
+                        error!("Failed to accept connection: {e}");
+                        continue;
+                    }
+                };
+
+                let io = TokioIo::new(stream);
+                let subs = subs.clone();
+
+                let service = service_fn(move |req: Request<Incoming>| {
+                    let subs = subs.clone();
+                    async move {
+                        let response = route(req, subs).await;
+                        Ok::<_, hyper::Error>(response)
+                    }
+                });
+
+                tokio::task::spawn(async move {
+                    if let Err(err) = hyper::server::conn::http1::Builder::new()
+                        .serve_connection(io, service)
+                        .await
+                    {
+                        error!("Error serving connection: {err}");
+                    }
+                });
+            }
+        });
+        Ok(HttpService { runtime })
+    }
+
+    pub fn shutdown(self) {
+        self.runtime.shutdown_timeout(Duration::from_secs(10));
+    }
+}
+
+async fn route(req: Request<Incoming>, subs: AccountSubscriptions) -> Response<Full<Bytes>> {
+    match (req.method(), req.uri().path()) {
+        (&Method::GET, "/metrics") => metrics_handler(),
+        (&Method::POST, "/filters/accounts") => {
+            subscriptions::handle_post_accounts(req, subs).await
+        }
+        _ => not_found(),
+    }
+}
+
+fn not_found() -> Response<Full<Bytes>> {
+    match Response::builder()
+        .status(StatusCode::NOT_FOUND)
+        .body(Full::new(Bytes::from("")))
+    {
+        Ok(resp) => resp,
+        Err(e) => {
+            error!("failed to build not found response: {e}");
+            Response::builder()
+                .status(StatusCode::NOT_FOUND)
+                .body(Full::new(Bytes::new()))
+                .unwrap_or_else(|_| {
+                    let (mut parts, _) = Response::new(Full::new(Bytes::new())).into_parts();
+                    parts.status = StatusCode::NOT_FOUND;
+                    Response::from_parts(parts, Full::new(Bytes::new()))
+                })
+        }
+    }
+}

--- a/src/server/prom.rs
+++ b/src/server/prom.rs
@@ -1,10 +1,8 @@
 use {
     crate::version::VERSION as VERSION_INFO,
     bytes::Bytes,
-    http::StatusCode,
     http_body_util::Full,
-    hyper::{Request, Response, body::Incoming, service::service_fn},
-    hyper_util::rt::TokioIo,
+    hyper::Response,
     log::*,
     prometheus::{GaugeVec, IntCounterVec, Opts, Registry, TextEncoder},
     rdkafka::{
@@ -12,9 +10,7 @@ use {
         producer::{DeliveryResult, ProducerContext},
         statistics::Statistics,
     },
-    std::{io::Result as IoResult, net::SocketAddr, sync::Once, time::Duration},
-    tokio::net::TcpListener,
-    tokio::runtime::Runtime,
+    std::sync::Once,
 };
 
 lazy_static::lazy_static! {
@@ -46,83 +42,37 @@ lazy_static::lazy_static! {
     ).unwrap();
 }
 
-#[derive(Debug)]
-pub struct PrometheusService {
-    runtime: Runtime,
+pub fn register_metrics() {
+    static REGISTER: Once = Once::new();
+    REGISTER.call_once(|| {
+        macro_rules! register {
+            ($collector:ident) => {
+                REGISTRY
+                    .register(Box::new($collector.clone()))
+                    .expect("collector can't be registered");
+            };
+        }
+        register!(VERSION);
+        register!(UPLOAD_ACCOUNTS_TOTAL);
+        register!(UPLOAD_SLOTS_TOTAL);
+        register!(UPLOAD_TRANSACTIONS_TOTAL);
+        register!(KAFKA_STATS);
+
+        for (key, value) in &[
+            ("version", VERSION_INFO.version),
+            ("solana", VERSION_INFO.solana),
+            ("git", VERSION_INFO.git),
+            ("rustc", VERSION_INFO.rustc),
+            ("buildts", VERSION_INFO.buildts),
+        ] {
+            VERSION
+                .with_label_values(&[key.to_string(), value.to_string()])
+                .inc();
+        }
+    });
 }
 
-impl PrometheusService {
-    pub fn new(address: SocketAddr) -> IoResult<Self> {
-        static REGISTER: Once = Once::new();
-        REGISTER.call_once(|| {
-            macro_rules! register {
-                ($collector:ident) => {
-                    REGISTRY
-                        .register(Box::new($collector.clone()))
-                        .expect("collector can't be registered");
-                };
-            }
-            register!(VERSION);
-            register!(UPLOAD_ACCOUNTS_TOTAL);
-            register!(UPLOAD_SLOTS_TOTAL);
-            register!(UPLOAD_TRANSACTIONS_TOTAL);
-            register!(KAFKA_STATS);
-
-            for (key, value) in &[
-                ("version", VERSION_INFO.version),
-                ("solana", VERSION_INFO.solana),
-                ("git", VERSION_INFO.git),
-                ("rustc", VERSION_INFO.rustc),
-                ("buildts", VERSION_INFO.buildts),
-            ] {
-                VERSION
-                    .with_label_values(&[key.to_string(), value.to_string()])
-                    .inc();
-            }
-        });
-
-        let runtime = Runtime::new()?;
-        runtime.spawn(async move {
-            let listener = TcpListener::bind(address).await.unwrap();
-
-            loop {
-                let (stream, _) = match listener.accept().await {
-                    Ok(conn) => conn,
-                    Err(e) => {
-                        error!("Failed to accept connection: {}", e);
-                        continue;
-                    }
-                };
-
-                let io = TokioIo::new(stream);
-
-                let service = service_fn(|req: Request<Incoming>| async move {
-                    let response = match req.uri().path() {
-                        "/metrics" => metrics_handler(),
-                        _ => not_found_handler(),
-                    };
-                    Ok::<_, hyper::Error>(response)
-                });
-
-                tokio::task::spawn(async move {
-                    if let Err(err) = hyper::server::conn::http1::Builder::new()
-                        .serve_connection(io, service)
-                        .await
-                    {
-                        error!("Error serving connection: {}", err);
-                    }
-                });
-            }
-        });
-        Ok(PrometheusService { runtime })
-    }
-
-    pub fn shutdown(self) {
-        self.runtime.shutdown_timeout(Duration::from_secs(10));
-    }
-}
-
-fn metrics_handler() -> Response<Full<Bytes>> {
+pub fn metrics_handler() -> Response<Full<Bytes>> {
     let metrics = TextEncoder::new()
         .encode_to_string(&REGISTRY.gather())
         .unwrap_or_else(|error| {
@@ -131,13 +81,6 @@ fn metrics_handler() -> Response<Full<Bytes>> {
         });
     Response::builder()
         .body(Full::new(Bytes::from(metrics)))
-        .unwrap()
-}
-
-fn not_found_handler() -> Response<Full<Bytes>> {
-    Response::builder()
-        .status(StatusCode::NOT_FOUND)
-        .body(Full::new(Bytes::from("")))
         .unwrap()
 }
 

--- a/src/server/subscriptions.rs
+++ b/src/server/subscriptions.rs
@@ -1,0 +1,176 @@
+use {
+    bytes::Bytes,
+    dashmap::DashSet,
+    http::StatusCode,
+    http_body_util::{Full, Limited},
+    hyper::{Request, Response, body::Incoming},
+    log::*,
+    solana_pubkey::Pubkey,
+    std::{str::FromStr, sync::Arc},
+};
+
+/// Maximum request body size: 1 MiB
+const MAX_BODY_SIZE: usize = 1024 * 1024;
+
+/// Shared dynamic account filter state backed by Arc<DashSet<[u8; 32]>>.
+/// Clone-cheap (Arc); uses DashSet's fine-grained sharded locking for concurrent access.
+/// Operations may acquire shard-level read/write locks and can block if concurrent
+/// operations hold the shard's lock. Not strictly lock-free, but provides better
+/// concurrency than a single global lock via per-shard locking.
+#[derive(Clone)]
+pub struct AccountSubscriptions {
+    inner: Arc<DashSet<[u8; 32]>>,
+}
+
+impl Default for AccountSubscriptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AccountSubscriptions {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(DashSet::new()),
+        }
+    }
+
+    /// Synchronous check for use in the geyser callback (non-async context).
+    /// Uses DashSet::contains to check membership. This method acquires a read lock
+    /// on the shard and may block if a concurrent write operation holds the shard's lock.
+    /// Suitable for synchronous use but not strictly lock-free.
+    pub fn contains_sync(&self, pubkey: &[u8; 32]) -> bool {
+        self.inner.contains(pubkey)
+    }
+
+    /// Add pubkeys, return new total count.
+    pub fn add<I: IntoIterator<Item = [u8; 32]>>(&self, pubkeys: I) -> usize {
+        for pk in pubkeys {
+            self.inner.insert(pk);
+        }
+        self.inner.len()
+    }
+}
+
+// ----- REST handler -----
+
+/// Request body for `POST /filters/accounts`.
+#[derive(serde::Deserialize)]
+struct AddAccountsRequest {
+    pubkeys: Vec<String>,
+}
+
+/// Response body.
+#[derive(serde::Serialize)]
+struct AccountsResponse {
+    active_count: usize,
+}
+
+#[derive(serde::Serialize)]
+struct ErrorResponse {
+    error: String,
+}
+
+/// Handle `POST /filters/accounts`.
+pub async fn handle_post_accounts(
+    req: Request<Incoming>,
+    subs: AccountSubscriptions,
+) -> Response<Full<Bytes>> {
+    use http_body_util::BodyExt;
+    let body_bytes = match Limited::new(req.into_body(), MAX_BODY_SIZE).collect().await {
+        Ok(collected) => collected.to_bytes(),
+        Err(e) => {
+            return if e
+                .downcast_ref::<http_body_util::LengthLimitError>()
+                .is_some()
+            {
+                error_response(
+                    StatusCode::PAYLOAD_TOO_LARGE,
+                    &format!("body exceeds max size of {MAX_BODY_SIZE} bytes"),
+                )
+            } else {
+                error_response(StatusCode::BAD_REQUEST, &format!("body read error: {e}"))
+            };
+        }
+    };
+
+    let parsed: AddAccountsRequest = match serde_json::from_slice(&body_bytes) {
+        Ok(v) => v,
+        Err(e) => return error_response(StatusCode::BAD_REQUEST, &format!("invalid JSON: {e}")),
+    };
+
+    let mut keys = Vec::with_capacity(parsed.pubkeys.len());
+    for pk_str in &parsed.pubkeys {
+        match Pubkey::from_str(pk_str) {
+            Ok(pk) => keys.push(pk.to_bytes()),
+            Err(_) => {
+                return error_response(
+                    StatusCode::BAD_REQUEST,
+                    &format!("invalid pubkey: {pk_str}"),
+                );
+            }
+        }
+    }
+
+    let active_count = subs.add(keys);
+    info!(
+        "Added {} pubkeys, active_count={active_count}",
+        parsed.pubkeys.len()
+    );
+
+    json_response(StatusCode::OK, &AccountsResponse { active_count })
+}
+
+fn json_response<T: serde::Serialize>(status: StatusCode, body: &T) -> Response<Full<Bytes>> {
+    let json = match serde_json::to_vec(body) {
+        Ok(j) => j,
+        Err(e) => {
+            error!("failed to serialize JSON response: {e}");
+            return error_500();
+        }
+    };
+
+    match Response::builder()
+        .status(status)
+        .header("content-type", "application/json")
+        .body(Full::new(Bytes::from(json)))
+    {
+        Ok(resp) => resp,
+        Err(e) => {
+            error!("failed to build response: {e}");
+            error_500()
+        }
+    }
+}
+
+fn error_500() -> Response<Full<Bytes>> {
+    match Response::builder()
+        .status(StatusCode::INTERNAL_SERVER_ERROR)
+        .header("content-type", "application/json")
+        .body(Full::new(Bytes::from(
+            r#"{"error":"internal server error"}"#,
+        ))) {
+        Ok(resp) => resp,
+        Err(_) => {
+            // Fallback: minimal response without headers
+            Response::builder()
+                .status(StatusCode::INTERNAL_SERVER_ERROR)
+                .body(Full::new(Bytes::new()))
+                .unwrap_or_else(|_| {
+                    // Final fallback: bare 500 response
+                    let (mut parts, _) = Response::new(Full::new(Bytes::new())).into_parts();
+                    parts.status = StatusCode::INTERNAL_SERVER_ERROR;
+                    Response::from_parts(parts, Full::new(Bytes::new()))
+                })
+        }
+    }
+}
+
+fn error_response(status: StatusCode, msg: &str) -> Response<Full<Bytes>> {
+    json_response(
+        status,
+        &ErrorResponse {
+            error: msg.to_owned(),
+        },
+    )
+}


### PR DESCRIPTION
## Summary

Add confirmed-only account publication by buffering account updates until their
slot reaches `Confirmed` or `Rooted`.

- add a `ConfirmedAccounts` state machine for per-slot account buffering and slot
  graph tracking
- infer confirmation for known live ancestor slots and drain buffered updates
  exactly once when a slot becomes confirmed
- remove buffered updates for dead branches and add a stale-slot fallback to
  bound memory for unresolved slots
- move account publication out of `update_account(...)` so confirmed updates are
  emitted from slot-status transitions instead

## Details

This change gates account publication on confirmation without changing the
existing slot, transaction, or block publication flow. Account updates are now
stored per slot and pubkey until the corresponding slot is confirmed, at which
point the buffered updates are released and published using the current dynamic
account subscriptions.

### Confirmed account state

The new `ConfirmedAccounts` type owns the confirmation state machine. It tracks
pending updates per slot, known parent and child slot links, confirmed slots,
dead slots, and the highest observed slot used by the stale-slot fallback.

It promotes slots to confirmed on direct `Confirmed` and `Rooted` callbacks and
walks up already-known parent links to infer confirmation for live ancestors.
Each slot drains its buffered account updates once, which keeps publication
idempotent even if status callbacks repeat.

### Cleanup behavior

Dead slots now remove their known descendant subtree from the in-memory state,
including buffered account updates that should never be published. A coarse
stale-slot eviction path remains as a defensive fallback for old unconfirmed
slots that never resolve, with logging to make those drops visible.

### Plugin integration

`KafkaPlugin` now owns a shared `Mutex<ConfirmedAccounts>` and uses short locked
sections only for state transitions. Account updates are built outside the lock
and recorded into the state machine, while filter checks and Kafka sends happen
after the lock is released.

Confirmed account publication intentionally follows dynamic account
subscriptions only. Program-based account publication is being deprecated and is
left unsupported in this path.

### Test coverage

The new isolated tests cover:

- overwrite behavior for repeated account updates in the same slot
- direct confirmation and rooted confirmation
- ancestor confirmation inference through known parent links
- reuse of previously observed parent links when later confirmations arrive with
  `parent=None`
- dead-slot cleanup and suppression of later emission
- stale fallback eviction behavior
- exact transition outputs and buffered-account cleanup across the main state
  transitions
